### PR TITLE
Modifying so this will work behind HTTPS as well

### DIFF
--- a/static/logical_js/logic.js
+++ b/static/logical_js/logic.js
@@ -19,7 +19,7 @@ $(function () {
     }
 
     if(wsEventBus==null){
-        wsEventBus = new WebSocket('ws://'+window.location.host+'/websocket');
+        wsEventBus = new WebSocket(window.location.protocol.replace('http','ws')+'//'+window.location.host+'/websocket');
         console.log("Server EventBus websocket was created"+ window.location.host);
 
         wsEventBus.onopen = function(evt) {


### PR DESCRIPTION
I'm replacing the 'http' in the protocol with 'ws'. If the protocol is just 'http' it will use 'ws' if it's 'https' it will end up being 'wss' (websocket secure)