### PR TITLE
Audio only option for web-ui and REST call

### DIFF
--- a/static/template/index.tpl
+++ b/static/template/index.tpl
@@ -44,6 +44,7 @@
                                     <option>360p</option>
                                     <option>240p</option>
                                     <option>144p</option>
+                                    <option>audio</option>
                                 </select>
                             </span>
                             <input name="url" id="url" type="url" class="form-control" placeholder="URL" >

--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -126,6 +126,8 @@ def download(url):
     result=""
     if (url[2] == "best"):
         result = subprocess.run(["youtube-dl", "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]", "--exec", "touch {} && mv {} ./downfolder/", "--merge-output-format", "mp4", url[0]])
+    elif (url[2] == "audio"):
+         result = subprocess.run(["youtube-dl", "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/", url[0]])
     else:
         resolution = url[2][:-1]
         result = subprocess.run(["youtube-dl", "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[height<="+resolution+"]+bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/",  url[0]])
@@ -146,6 +148,8 @@ def download_rest(url):
     result=""
     if (url[2] == "best"):
         result = subprocess.run(["youtube-dl", "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]", "--exec", "touch {} && mv {} ./downfolder/", "--merge-output-format", "mp4", url[0]])
+    elif (url[2] == "audio"):
+         result = subprocess.run(["youtube-dl", "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/", url[0]])
     else:
         resolution = url[2][:-1]
         result = subprocess.run(["youtube-dl", "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[height<="+resolution+"]+bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/",  url[0]])
@@ -159,8 +163,8 @@ class Thr:
         self.dl_thread.start()
 
 
-dl_q = Queue();
-done = False;
+dl_q = Queue()
+done = False
 Thr.dl_thread = Thread(target=dl_worker)
 Thr.dl_thread.start()
 


### PR DESCRIPTION
Hi! youtube-dl already supported it so I just added an option on the html template and added the code to download audio only. 
It downloads audio in m4a for now but I know youtube-dl also support mp3 conversion.