### PR TITLE
Fix random mkv or mp4 format when specifying resolution

### DIFF
--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -122,18 +122,24 @@ def dl_worker():
         dl_q.task_done()
 
 
+def build_youtube_dl_cmd(url):
+    if (url[2] == "best"):
+        cmd = ["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]", "--exec", "touch {} && mv {} ./downfolder/", "--merge-output-format", "mp4", url[0]]
+    # url[2] == "audio" for download_rest()
+    elif (url[2] == "audio-m4a" or url[2] == "audio"):
+        cmd = ["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/", url[0]]
+    elif (url[2] == "audio-mp3"):
+        cmd = ["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestaudio[ext=m4a]", "-x", "--audio-format", "mp3", "--exec", "touch {} && mv {} ./downfolder/", url[0]]
+    else:
+        resolution = url[2][:-1]
+        cmd = ["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[height<="+resolution+"]+bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/",  url[0]]
+    return cmd
+
+
 def download(url):
     # url[1].send("[MSG], [Started] downloading   " + url[0] + "  resolution below " + url[2])
     result=""
-    if (url[2] == "best"):
-        result = subprocess.run(["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]", "--exec", "touch {} && mv {} ./downfolder/", "--merge-output-format", "mp4", url[0]])
-    elif (url[2] == "audio-m4a"):
-         result = subprocess.run(["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/", url[0]])
-    elif (url[2] == "audio-mp3"):
-         result = subprocess.run(["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestaudio[ext=m4a]", "-x", "--audio-format", "mp3", "--exec", "touch {} && mv {} ./downfolder/", url[0]])
-    else:
-        resolution = url[2][:-1]
-        result = subprocess.run(["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[height<="+resolution+"]+bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/",  url[0]])
+    result = subprocess.run(build_youtube_dl_cmd(url))
     try:
         if(result.returncode==0):
             url[1].send("[MSG], [Finished] " + url[0] + "  resolution below " + url[2]+", Remain download Count "+ json.dumps(dl_q.qsize()))
@@ -148,13 +154,8 @@ def download(url):
 
 def download_rest(url):
     result=""
-    if (url[2] == "best"):
-        result = subprocess.run(["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]", "--exec", "touch {} && mv {} ./downfolder/", "--merge-output-format", "mp4", url[0]])
-    elif (url[2] == "audio"):
-         result = subprocess.run(["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/", url[0]])
-    else:
-        resolution = url[2][:-1]
-        result = subprocess.run(["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[height<="+resolution+"]+bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/",  url[0]])
+    result = subprocess.run(build_youtube_dl_cmd(url))
+
 
 class Thr:
     def __init__(self):

--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -133,6 +133,7 @@ def build_youtube_dl_cmd(url):
     else:
         resolution = url[2][:-1]
         cmd = ["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[height<="+resolution+"]+bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/",  url[0]]
+    print (" ".join(cmd))
     return cmd
 
 

--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -132,7 +132,7 @@ def build_youtube_dl_cmd(url):
         cmd = ["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestaudio[ext=m4a]", "-x", "--audio-format", "mp3", "--exec", "touch {} && mv {} ./downfolder/", url[0]]
     else:
         resolution = url[2][:-1]
-        cmd = ["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[height<="+resolution+"]+bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/",  url[0]]
+        cmd = ["youtube-dl", "--proxy", proxy, "-o", "./downfolder/.incomplete/%(title)s.%(ext)s", "-f", "bestvideo[height<="+resolution+"][ext=mp4]+bestaudio[ext=m4a]", "--exec", "touch {} && mv {} ./downfolder/",  url[0]]
     print (" ".join(cmd))
     return cmd
 


### PR DESCRIPTION
`mp4` format is preferred for a wider compatibility with older devices.

This fix is inline with the existing `(url[2] == "best")` case that also prefer `mp4` format.

For the following sample list of formats, before this fix, given
`resolution=720`, it will select format code 247 instead of 136 because 247 is
after 136 and resulting in the `mkv` file container format instead of `mp4`.

```
format code  extension  resolution note
249          webm       audio only tiny   48k , webm_dash container, opus @ 48k (48000Hz), 8.49MiB
250          webm       audio only tiny   61k , webm_dash container, opus @ 61k (48000Hz), 10.87MiB
251          webm       audio only tiny  118k , webm_dash container, opus @118k (48000Hz), 20.99MiB
140          m4a        audio only tiny  129k , m4a_dash container, mp4a.40.2@129k (44100Hz), 22.91MiB
160          mp4        256x144    144p   47k , mp4_dash container, avc1.4d400c@  47k, 30fps, video only, 8.38MiB
278          webm       256x144    144p   73k , webm_dash container, vp9@  73k, 30fps, video only, 12.94MiB
133          mp4        426x240    240p   90k , mp4_dash container, avc1.4d4015@  90k, 30fps, video only, 15.96MiB
242          webm       426x240    240p  123k , webm_dash container, vp9@ 123k, 30fps, video only, 21.91MiB
134          mp4        640x360    360p  154k , mp4_dash container, avc1.4d401e@ 154k, 30fps, video only, 27.25MiB
243          webm       640x360    360p  233k , webm_dash container, vp9@ 233k, 30fps, video only, 41.23MiB
135          mp4        854x480    480p  247k , mp4_dash container, avc1.4d401f@ 247k, 30fps, video only, 43.70MiB
244          webm       854x480    480p  362k , webm_dash container, vp9@ 362k, 30fps, video only, 64.12MiB
136          mp4        1280x720   720p  408k , mp4_dash container, avc1.4d401f@ 408k, 30fps, video only, 72.24MiB
247          webm       1280x720   720p  602k , webm_dash container, vp9@ 602k, 30fps, video only, 106.56MiB
248          webm       1920x1080  1080p 1083k , webm_dash container, vp9@1083k, 30fps, video only, 191.63MiB
137          mp4        1920x1080  1080p 1128k , mp4_dash container, avc1.640028@1128k, 30fps, video only, 199.59MiB
18           mp4        640x360    360p  420k , avc1.42001E, 30fps, mp4a.40.2 (44100Hz), 74.34MiB
22           mp4        1280x720   720p 1302k , avc1.64001F, 30fps, mp4a.40.2 (44100Hz) (best)
```