### PR TITLE
feat(backend): Wave 2b — download manager and legacy REST API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,14 +9,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import init_db
 from app.models.download import Download  # noqa: F401 — Base.metadata 등록용
-from app.routers import auth, health
+from app.routers import auth, download, health, legacy
+from app.services.download_manager import download_manager
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """Application lifespan: initialize DB on startup."""
+    """Application lifespan: initialize DB on startup, manage download worker."""
     await init_db()
+    await download_manager.start()
     yield
+    await download_manager.stop()
 
 
 app = FastAPI(
@@ -35,3 +38,5 @@ app.add_middleware(
 
 app.include_router(health.router)
 app.include_router(auth.router)
+app.include_router(download.router)
+app.include_router(legacy.router)

--- a/backend/app/routers/download.py
+++ b/backend/app/routers/download.py
@@ -1,0 +1,73 @@
+"""v2 download API endpoints (JWT-protected)."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.download import Download
+from app.schemas.download import (
+    DownloadCreate,
+    DownloadHistoryResponse,
+    DownloadResponse,
+)
+from app.services.download_manager import download_manager
+
+router = APIRouter(prefix="/api/downloads", tags=["downloads"])
+
+
+@router.post("", response_model=DownloadResponse, status_code=status.HTTP_201_CREATED)
+async def create_download(
+    request: DownloadCreate,
+    db: AsyncSession = Depends(get_db),
+    _user: str = Depends(get_current_user),
+) -> DownloadResponse:
+    """Enqueue a new download."""
+    download_id = await download_manager.enqueue(request.url, request.resolution)
+    result = await db.execute(select(Download).where(Download.id == download_id))
+    download = result.scalar_one_or_none()
+    if not download:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create download record",
+        )
+    return DownloadResponse.model_validate(download)
+
+
+@router.get("/history", response_model=DownloadHistoryResponse)
+async def get_history(
+    skip: int = 0,
+    limit: int = 20,
+    db: AsyncSession = Depends(get_db),
+    _user: str = Depends(get_current_user),
+) -> DownloadHistoryResponse:
+    """Retrieve download history with pagination."""
+    count_result = await db.execute(select(func.count(Download.id)))
+    total = count_result.scalar()
+
+    result = await db.execute(
+        select(Download)
+        .order_by(Download.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
+    items = [DownloadResponse.model_validate(row) for row in result.scalars().all()]
+    return DownloadHistoryResponse(total=total, items=items)
+
+
+@router.delete("/history/{download_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_history_item(
+    download_id: str,
+    db: AsyncSession = Depends(get_db),
+    _user: str = Depends(get_current_user),
+) -> None:
+    """Delete a download history record (DB only, no file deletion)."""
+    result = await db.execute(select(Download).where(Download.id == download_id))
+    download = result.scalar_one_or_none()
+    if not download:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Download record not found",
+        )
+    await db.delete(download)

--- a/backend/app/routers/legacy.py
+++ b/backend/app/routers/legacy.py
@@ -1,3 +1,34 @@
-# Legacy REST API endpoint (POST /youtube-dl/rest)
-# Will be implemented in Wave 2b with full backward compatibility
-# See: wave1-backend-spec.md "레거시 REST API 하위호환" 섹션
+"""Legacy v1 API compatibility router (POST /youtube-dl/rest)."""
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from app.schemas.legacy import LegacyDownloadRequest
+from app.services.auth_service import verify_credentials
+from app.services.download_manager import download_manager
+
+router = APIRouter(tags=["legacy"])
+
+
+@router.post("/youtube-dl/rest")
+async def legacy_download(request: LegacyDownloadRequest) -> JSONResponse:
+    """Handle legacy download requests with the original v1 response format.
+
+    Always returns HTTP 200 for backward compatibility — errors are
+    communicated via the JSON body.
+    """
+    if not verify_credentials(request.id, request.pw):
+        return JSONResponse(
+            content={"success": False, "msg": "Invalid password or account."}
+        )
+
+    remaining = str(await download_manager.get_queue_size())
+    await download_manager.enqueue(request.url, request.resolution)
+
+    return JSONResponse(
+        content={
+            "success": True,
+            "msg": "download has started",
+            "Remaining downloading count": remaining,
+        }
+    )

--- a/backend/app/schemas/legacy.py
+++ b/backend/app/schemas/legacy.py
@@ -1,0 +1,12 @@
+"""Legacy v1 API request/response schemas."""
+
+from pydantic import BaseModel
+
+
+class LegacyDownloadRequest(BaseModel):
+    """Request body for POST /youtube-dl/rest (v1 compatible)."""
+
+    url: str
+    resolution: str = "best"
+    id: str = ""
+    pw: str = ""

--- a/backend/app/services/download_manager.py
+++ b/backend/app/services/download_manager.py
@@ -1,0 +1,134 @@
+"""Async download queue manager with a single background worker."""
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+
+from app.config import settings
+from app.database import AsyncSessionLocal
+from app.models.download import Download
+from app.services.ytdlp_service import extract_metadata, run_download
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadManager:
+    """Manages a FIFO download queue with a single async worker."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[str] = asyncio.Queue()
+        self._worker_task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Start the background worker."""
+        self._worker_task = asyncio.create_task(self._worker())
+        logger.info("DownloadManager worker started")
+
+    async def stop(self) -> None:
+        """Stop the background worker."""
+        if self._worker_task:
+            self._worker_task.cancel()
+            try:
+                await self._worker_task
+            except asyncio.CancelledError:
+                pass
+            self._worker_task = None
+        logger.info("DownloadManager worker stopped")
+
+    async def enqueue(self, url: str, resolution: str = "best") -> str:
+        """Create a download record and add it to the queue."""
+        download_id = str(uuid.uuid4())
+        async with AsyncSessionLocal() as session:
+            download = Download(
+                id=download_id,
+                url=url,
+                resolution=resolution,
+                status="queued",
+                progress=0.0,
+            )
+            session.add(download)
+            await session.commit()
+
+        await self._queue.put(download_id)
+        logger.info("Enqueued download %s for %s", download_id, url)
+        return download_id
+
+    async def get_queue_size(self) -> int:
+        """Return the number of items waiting in the queue."""
+        return self._queue.qsize()
+
+    async def _worker(self) -> None:
+        """Continuously process downloads from the queue."""
+        while True:
+            download_id = await self._queue.get()
+            try:
+                await self._process_download(download_id)
+            except Exception:
+                logger.exception("Error processing download %s", download_id)
+                await self._update_status(download_id, "failed")
+            finally:
+                self._queue.task_done()
+
+    async def _process_download(self, download_id: str) -> None:
+        """Execute a single download: metadata → download → DB update."""
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            download = result.scalar_one_or_none()
+            if not download:
+                logger.error("Download %s not found in DB", download_id)
+                return
+
+            url = download.url
+            resolution = download.resolution or "best"
+
+        # Extract metadata
+        meta = await extract_metadata(url)
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            download = result.scalar_one_or_none()
+            if download:
+                download.title = meta.title
+                download.channel = meta.channel
+                download.thumbnail_url = meta.thumbnail_url
+                download.status = "downloading"
+                download.progress = 5.0
+                await session.commit()
+
+        # Run download and track progress
+        async for progress in run_download(url, resolution):
+            async with AsyncSessionLocal() as session:
+                result = await session.execute(
+                    select(Download).where(Download.id == download_id)
+                )
+                download = result.scalar_one_or_none()
+                if download:
+                    download.progress = progress.percent
+                    download.status = progress.status
+                    if progress.filename:
+                        download.filename = progress.filename
+                        download.filepath = f"{settings.DOWNLOAD_DIR}/{progress.filename}"
+                    if progress.status == "completed":
+                        download.progress = 100.0
+                        download.completed_at = datetime.now(timezone.utc)
+                    await session.commit()
+
+    async def _update_status(self, download_id: str, status: str) -> None:
+        """Update the status of a download record."""
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            download = result.scalar_one_or_none()
+            if download:
+                download.status = status
+                await session.commit()
+
+
+download_manager = DownloadManager()

--- a/backend/app/services/ytdlp_service.py
+++ b/backend/app/services/ytdlp_service.py
@@ -1,0 +1,188 @@
+"""yt-dlp async wrapper for metadata extraction and downloads."""
+
+import asyncio
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import AsyncGenerator
+
+from app.config import settings
+
+UNSAFE_CHARS_PATTERN = "[\\\\/:*?\"'<>|&+\\$%@!~`=;,^#(){}\\[\\] ]"
+SAFE_REPLACEMENT = "_"
+
+
+@dataclass
+class VideoMetadata:
+    """Extracted video metadata."""
+
+    title: str | None = None
+    channel: str | None = None
+    thumbnail_url: str | None = None
+
+
+@dataclass
+class DownloadProgress:
+    """Progress update from a running download."""
+
+    percent: float
+    status: str  # "downloading", "merging", "completed", "failed"
+    filename: str | None = None
+
+
+async def extract_metadata(url: str) -> VideoMetadata:
+    """Extract title, channel, and thumbnail from a URL using yt-dlp --dump-json."""
+    cmd = ["yt-dlp", "--dump-json", "--no-download", "--no-warnings", url]
+    if settings.PROXY:
+        cmd.insert(1, "--proxy")
+        cmd.insert(2, settings.PROXY)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
+        if proc.returncode == 0 and stdout:
+            data = json.loads(stdout.decode().strip().split("\n")[0])
+            return VideoMetadata(
+                title=data.get("title"),
+                channel=data.get("uploader"),
+                thumbnail_url=data.get("thumbnail"),
+            )
+    except Exception:
+        pass
+    return VideoMetadata()
+
+
+def build_download_cmd(url: str, resolution: str) -> list[str]:
+    """Build yt-dlp command arguments based on resolution. Mirrors v1 logic."""
+    download_dir = settings.DOWNLOAD_DIR
+    incomplete_dir = os.path.join(download_dir, ".incomplete")
+
+    base = ["yt-dlp", "--retry-sleep", "1"]
+    if settings.PROXY:
+        base.extend(["--proxy", settings.PROXY])
+    base.extend([
+        "--replace-in-metadata", "title", UNSAFE_CHARS_PATTERN, SAFE_REPLACEMENT,
+    ])
+
+    if resolution == "best":
+        return [
+            *base,
+            "-o", f"{incomplete_dir}/%(title)s.%(ext)s",
+            "-f", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]",
+            "--exec", f"touch {{}} && mv {{}} {download_dir}/",
+            "--merge-output-format", "mp4",
+            url,
+        ]
+    elif resolution in ("audio-m4a", "audio"):
+        return [
+            *base,
+            "-o", f"{incomplete_dir}/%(title)s.%(ext)s",
+            "-f", "bestaudio[ext=m4a]",
+            "--exec", f"touch {{}} && mv {{}} {download_dir}/",
+            url,
+        ]
+    elif resolution == "audio-mp3":
+        return [
+            *base,
+            "-o", f"{incomplete_dir}/%(title)s.%(ext)s",
+            "-f", "bestaudio[ext=m4a]",
+            "-x", "--audio-format", "mp3",
+            "--exec", f"touch {{}} && mv {{}} {download_dir}/",
+            url,
+        ]
+    elif re.match(r"(vtt|srt)", resolution):
+        parts = resolution.split("|")
+        sub_format = parts[0]
+        sub_lang = parts[1] if len(parts) > 1 else "en"
+        return [
+            *base,
+            "-o", f"{download_dir}/%(title)s.%(ext)s",
+            "--write-auto-subs", "--sub-langs", sub_lang,
+            "--sub-format", sub_format, "--skip-download",
+            url,
+        ]
+    else:
+        # e.g. "1080p" → height<=1080
+        height = resolution.rstrip("p")
+        return [
+            *base,
+            "-o", f"{incomplete_dir}/%(title)s.%(ext)s",
+            "-f", f"bestvideo[height<={height}][ext=mp4]+bestaudio[ext=m4a]",
+            "--exec", f"touch {{}} && mv {{}} {download_dir}/",
+            url,
+        ]
+
+
+async def run_download(url: str, resolution: str) -> AsyncGenerator[DownloadProgress, None]:
+    """Run yt-dlp download and yield progress updates."""
+    cmd = build_download_cmd(url, resolution)
+    download_dir = settings.DOWNLOAD_DIR
+    is_subtitle = bool(re.match(r"(vtt|srt)", resolution))
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+    filename: str | None = None
+    filepath: str | None = None
+    current_progress = 0.0
+
+    while True:
+        line_bytes = await proc.stdout.readline()
+        if not line_bytes:
+            break
+        line = line_bytes.decode(errors="replace").strip()
+
+        # Extract filename
+        if is_subtitle and not filepath:
+            m = re.search(
+                r"\[(?:info|download)\] (?:Writing video subtitles to|Destination): (.+?\.(srt|vtt))",
+                line,
+            )
+            if m:
+                filepath = m.group(1)
+                filename = os.path.basename(filepath)
+        elif not filepath:
+            m = re.search(
+                r"touch\s+['\"]?(.+?)['\"]?\s+&&\s+mv\s+['\"]?(.+?)['\"]?\s+",
+                line,
+            )
+            if m:
+                source_path = m.group(2)
+                filename = os.path.basename(source_path)
+                filepath = os.path.join(download_dir, filename)
+
+        # Progress extraction
+        progress_match = re.search(r"\[download\]\s+(\d+(?:\.\d+)?)%", line)
+        if progress_match:
+            raw_progress = float(progress_match.group(1))
+            adjusted = 5 + (raw_progress * 0.90)
+            if abs(adjusted - current_progress) >= 1:
+                current_progress = adjusted
+                yield DownloadProgress(
+                    percent=adjusted,
+                    status="downloading",
+                    filename=filename,
+                )
+
+        # Merge detection
+        if "[Merger] Merging formats" in line:
+            current_progress = 95.0
+            yield DownloadProgress(
+                percent=95.0,
+                status="merging",
+                filename=filename,
+            )
+
+    await proc.wait()
+
+    if proc.returncode == 0:
+        yield DownloadProgress(percent=100.0, status="completed", filename=filename)
+    else:
+        yield DownloadProgress(percent=current_progress, status="failed", filename=filename)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,3 +9,16 @@ def override_settings(monkeypatch):
     monkeypatch.setattr(settings, "MY_ID", "admin")
     monkeypatch.setattr(settings, "MY_PW", "admin")
     monkeypatch.setattr(settings, "SECRET_KEY", "test-secret-key-for-testing")
+
+
+@pytest.fixture(autouse=True)
+async def init_test_db():
+    """Ensure DB tables exist for every test."""
+    from app.database import Base, engine
+    from app.models.download import Download  # noqa: F401
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)

--- a/backend/tests/test_download.py
+++ b/backend/tests/test_download.py
@@ -1,0 +1,73 @@
+"""Tests for v2 download API endpoints."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+async def _get_auth_headers(client: AsyncClient) -> dict:
+    """Helper to get JWT auth headers."""
+    resp = await client.post(
+        "/api/auth/login",
+        json={"id": "admin", "pw": "admin"},
+    )
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_create_download() -> None:
+    """POST /api/downloads with valid JWT should enqueue and return 201."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = await _get_auth_headers(client)
+        response = await client.post(
+            "/api/downloads",
+            json={"url": "https://example.com/video", "resolution": "best"},
+            headers=headers,
+        )
+    assert response.status_code == 201
+    data = response.json()
+    assert "id" in data
+    assert data["status"] == "queued"
+    assert data["url"] == "https://example.com/video"
+
+
+@pytest.mark.asyncio
+async def test_create_download_no_auth() -> None:
+    """POST /api/downloads without JWT should return 403."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/downloads",
+            json={"url": "https://example.com/video"},
+        )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_history() -> None:
+    """GET /api/downloads/history with JWT should return paginated list."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = await _get_auth_headers(client)
+        response = await client.get("/api/downloads/history", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert "total" in data
+    assert "items" in data
+    assert isinstance(data["items"], list)
+
+
+@pytest.mark.asyncio
+async def test_delete_history_not_found() -> None:
+    """DELETE nonexistent download should return 404."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = await _get_auth_headers(client)
+        response = await client.delete(
+            "/api/downloads/history/nonexistent-id",
+            headers=headers,
+        )
+    assert response.status_code == 404

--- a/backend/tests/test_legacy.py
+++ b/backend/tests/test_legacy.py
@@ -1,0 +1,61 @@
+"""Tests for legacy REST API endpoint (POST /youtube-dl/rest)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+@patch("app.routers.legacy.download_manager")
+async def test_legacy_download_success(mock_dm) -> None:
+    """Valid credentials should enqueue and return v1 success format."""
+    mock_dm.enqueue = AsyncMock(return_value="fake-id")
+    mock_dm.get_queue_size = AsyncMock(return_value=0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/youtube-dl/rest",
+            json={"url": "https://example.com/video", "resolution": "best", "id": "admin", "pw": "admin"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["msg"] == "download has started"
+    assert "Remaining downloading count" in data
+    mock_dm.enqueue.assert_awaited_once_with("https://example.com/video", "best")
+
+
+@pytest.mark.asyncio
+async def test_legacy_download_invalid_credentials() -> None:
+    """Wrong credentials should return 200 with v1 failure format."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/youtube-dl/rest",
+            json={"url": "https://example.com/video", "id": "wrong", "pw": "wrong"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    assert data["msg"] == "Invalid password or account."
+
+
+@pytest.mark.asyncio
+@patch("app.routers.legacy.download_manager")
+async def test_legacy_response_key_names(mock_dm) -> None:
+    """Response must use exact v1 key names including spaces."""
+    mock_dm.enqueue = AsyncMock(return_value="fake-id")
+    mock_dm.get_queue_size = AsyncMock(return_value=2)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/youtube-dl/rest",
+            json={"url": "https://example.com/video", "id": "admin", "pw": "admin"},
+        )
+    data = response.json()
+    # Exact key names from v1 — "Remaining downloading count" with spaces
+    assert set(data.keys()) == {"success", "msg", "Remaining downloading count"}
+    assert data["Remaining downloading count"] == "2"


### PR DESCRIPTION
## Summary
Core download pipeline: async download manager, yt-dlp service, legacy API backward compatibility.

## New Files
- app/services/download_manager.py — async queue + background worker (singleton)
- app/services/ytdlp_service.py — yt-dlp async wrapper (metadata + download)
- app/routers/download.py — POST /api/downloads, GET /history, DELETE /history/<id>
- app/routers/legacy.py — POST /youtube-dl/rest (v1 backward compatible)
- app/schemas/legacy.py — v1 request/response schemas
- tests/test_download.py — v2 API tests (4 cases)
- tests/test_legacy.py — legacy API backward compat tests (3 cases)

## Modified Files
- app/main.py — added download + legacy routers, download_manager start/stop in lifespan

## Key Design Decisions
- Legacy API returns HTTP 200 even on auth failure (v1 compat)
- Response key "Remaining downloading count" with spaces preserved exactly
- DELETE /history/<id> removes DB record only — NO file deletion (#47 fix)
- yt-dlp metadata: single --dump-json call instead of v1's 3 subprocess calls
- Progress mapping: 5 + (raw * 0.90) — same as v1

## Verification
- [x] POST /youtube-dl/rest v1 response format exact match
- [x] POST /youtube-dl/rest auth failure → HTTP 200 (not 401)
- [x] POST /api/downloads without JWT → 403
- [x] POST /api/downloads with JWT → 201
- [x] GET /api/downloads/history with JWT → 200
- [x] DELETE /api/downloads/history/<id> — DB only, no file deletion
- [x] pytest 15 tests passed
- [x] ruff check passed

## What's Next
- Wave 2c: WebSocket handler (real-time progress)
- Wave 3a: Error handling (#49, #47)