### PR TITLE
feat(backend): Wave 2c — WebSocket handler with real-time progress broadcast

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,12 +11,15 @@ from app.database import init_db
 from app.models.download import Download  # noqa: F401 — Base.metadata 등록용
 from app.routers import auth, download, health, legacy
 from app.services.download_manager import download_manager
+from app.ws.handler import router as ws_router
+from app.ws.manager import ws_manager
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan: initialize DB on startup, manage download worker."""
     await init_db()
+    download_manager.set_broadcast(ws_manager.broadcast)
     await download_manager.start()
     yield
     await download_manager.stop()
@@ -40,3 +43,4 @@ app.include_router(health.router)
 app.include_router(auth.router)
 app.include_router(download.router)
 app.include_router(legacy.router)
+app.include_router(ws_router)

--- a/backend/app/services/download_manager.py
+++ b/backend/app/services/download_manager.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 
 from sqlalchemy import select
@@ -21,6 +22,27 @@ class DownloadManager:
     def __init__(self) -> None:
         self._queue: asyncio.Queue[str] = asyncio.Queue()
         self._worker_task: asyncio.Task | None = None
+        self._current_download_id: str | None = None
+        self._broadcast_fn: Callable[..., Awaitable[None]] | None = None
+
+    def set_broadcast(self, fn: Callable[..., Awaitable[None]]) -> None:
+        """Set broadcast callback. Called from main.py lifespan."""
+        self._broadcast_fn = fn
+
+    @property
+    def current_download_id(self) -> str | None:
+        """Return the ID of the currently processing download."""
+        return self._current_download_id
+
+    @property
+    def queue_size(self) -> int:
+        """Return the number of items waiting in the queue."""
+        return self._queue.qsize()
+
+    async def _broadcast(self, message: dict) -> None:
+        """Send a message via the broadcast callback if set."""
+        if self._broadcast_fn:
+            await self._broadcast_fn(message)
 
     async def start(self) -> None:
         """Start the background worker."""
@@ -64,12 +86,18 @@ class DownloadManager:
         """Continuously process downloads from the queue."""
         while True:
             download_id = await self._queue.get()
+            self._current_download_id = download_id
             try:
                 await self._process_download(download_id)
-            except Exception:
+            except Exception as exc:
                 logger.exception("Error processing download %s", download_id)
                 await self._update_status(download_id, "failed")
+                await self._broadcast({
+                    "type": "failed",
+                    "data": {"download_id": download_id, "error": str(exc)},
+                })
             finally:
+                self._current_download_id = None
                 self._queue.task_done()
 
     async def _process_download(self, download_id: str) -> None:
@@ -101,6 +129,16 @@ class DownloadManager:
                 download.progress = 5.0
                 await session.commit()
 
+        await self._broadcast({
+            "type": "metadata",
+            "data": {
+                "download_id": download_id,
+                "title": meta.title,
+                "channel": meta.channel,
+                "thumbnail_url": meta.thumbnail_url,
+            },
+        })
+
         # Run download and track progress
         async for progress in run_download(url, resolution):
             async with AsyncSessionLocal() as session:
@@ -118,6 +156,25 @@ class DownloadManager:
                         download.progress = 100.0
                         download.completed_at = datetime.now(timezone.utc)
                     await session.commit()
+
+            await self._broadcast({
+                "type": "progress",
+                "data": {
+                    "download_id": download_id,
+                    "percent": progress.percent,
+                    "status": progress.status,
+                },
+            })
+
+            if progress.status == "completed":
+                await self._broadcast({
+                    "type": "complete",
+                    "data": {
+                        "download_id": download_id,
+                        "filename": progress.filename,
+                        "status": "completed",
+                    },
+                })
 
     async def _update_status(self, download_id: str, status: str) -> None:
         """Update the status of a download record."""

--- a/backend/app/ws/handler.py
+++ b/backend/app/ws/handler.py
@@ -1,0 +1,94 @@
+"""WebSocket endpoint for real-time download status updates."""
+
+import json
+import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from sqlalchemy import select
+
+from app.database import AsyncSessionLocal
+from app.models.download import Download
+from app.services.download_manager import download_manager
+from app.ws.manager import ws_manager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    """Handle WebSocket connections for real-time status updates."""
+    await ws_manager.connect(websocket)
+
+    # Auto-push current state on connect
+    await _send_state(websocket)
+    await _send_history(websocket)
+
+    try:
+        while True:
+            data = await websocket.receive_text()
+            try:
+                message = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+
+            msg_type = message.get("type")
+
+            if msg_type == "request_state":
+                await _send_state(websocket)
+
+            elif msg_type == "request_history":
+                await _send_history(websocket)
+
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        logger.error("WebSocket error: %s", e)
+    finally:
+        await ws_manager.disconnect(websocket)
+
+
+async def _send_state(websocket: WebSocket) -> None:
+    """Send current download state to a single client."""
+    state = {
+        "type": "state",
+        "data": {
+            "is_downloading": download_manager.current_download_id is not None,
+            "current_download_id": download_manager.current_download_id,
+            "queue_size": download_manager.queue_size,
+            "connected_clients": ws_manager.client_count,
+        },
+    }
+    await ws_manager.send_personal(websocket, state)
+
+
+async def _send_history(websocket: WebSocket) -> None:
+    """Send download history to a single client."""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(Download).order_by(Download.created_at.desc()).limit(100)
+        )
+        items = result.scalars().all()
+        for item in items:
+            await ws_manager.send_personal(websocket, {
+                "type": "history_item",
+                "data": {
+                    "id": item.id,
+                    "url": item.url,
+                    "title": item.title,
+                    "channel": item.channel,
+                    "thumbnail_url": item.thumbnail_url,
+                    "resolution": item.resolution,
+                    "status": item.status,
+                    "progress": item.progress,
+                    "filename": item.filename,
+                    "filepath": item.filepath,
+                    "created_at": item.created_at.isoformat() if item.created_at else None,
+                    "completed_at": item.completed_at.isoformat() if item.completed_at else None,
+                },
+            })
+        await ws_manager.send_personal(websocket, {
+            "type": "history_complete",
+            "data": {"total": len(items)},
+        })

--- a/backend/app/ws/manager.py
+++ b/backend/app/ws/manager.py
@@ -1,0 +1,51 @@
+"""WebSocket connection manager for real-time broadcast."""
+
+import logging
+
+from fastapi import WebSocket
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectionManager:
+    """Manages WebSocket client connections and broadcasting."""
+
+    def __init__(self) -> None:
+        self._clients: set[WebSocket] = set()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        """Accept a WebSocket connection and register the client."""
+        await websocket.accept()
+        self._clients.add(websocket)
+        logger.info("WebSocket connected. Total: %d", len(self._clients))
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        """Unregister a WebSocket client."""
+        self._clients.discard(websocket)
+        logger.info("WebSocket disconnected. Total: %d", len(self._clients))
+
+    async def broadcast(self, message: dict) -> None:
+        """Send a JSON message to all connected clients."""
+        disconnected: set[WebSocket] = set()
+        for client in self._clients:
+            try:
+                await client.send_json(message)
+            except Exception:
+                disconnected.add(client)
+        for client in disconnected:
+            self._clients.discard(client)
+
+    async def send_personal(self, websocket: WebSocket, message: dict) -> None:
+        """Send a JSON message to a specific client."""
+        try:
+            await websocket.send_json(message)
+        except Exception:
+            self._clients.discard(websocket)
+
+    @property
+    def client_count(self) -> int:
+        """Return the number of connected clients."""
+        return len(self._clients)
+
+
+ws_manager = ConnectionManager()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 
 import app.services.download_manager as dm_module
+import app.ws.handler as ws_handler_module
 from app.config import settings
 from app.database import Base, get_db
 from app.main import app
@@ -32,7 +33,8 @@ async def setup_test_db():
 @pytest.fixture(autouse=True)
 def override_db_dependency():
     """Override get_db and download_manager's session to use test DB."""
-    original_session = dm_module.AsyncSessionLocal
+    original_dm_session = dm_module.AsyncSessionLocal
+    original_ws_session = ws_handler_module.AsyncSessionLocal
 
     async def _get_test_db():
         async with TestSessionLocal() as session:
@@ -45,9 +47,11 @@ def override_db_dependency():
 
     app.dependency_overrides[get_db] = _get_test_db
     dm_module.AsyncSessionLocal = TestSessionLocal
+    ws_handler_module.AsyncSessionLocal = TestSessionLocal
     yield
     app.dependency_overrides.clear()
-    dm_module.AsyncSessionLocal = original_session
+    dm_module.AsyncSessionLocal = original_dm_session
+    ws_handler_module.AsyncSessionLocal = original_ws_session
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_download.py
+++ b/backend/tests/test_download.py
@@ -43,7 +43,7 @@ async def test_create_download_no_auth() -> None:
             "/api/downloads",
             json={"url": "https://example.com/video"},
         )
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_download.py
+++ b/backend/tests/test_download.py
@@ -43,7 +43,7 @@ async def test_create_download_no_auth() -> None:
             "/api/downloads",
             json={"url": "https://example.com/video"},
         )
-    assert response.status_code == 401
+    assert response.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -1,0 +1,66 @@
+"""Tests for WebSocket endpoint."""
+
+from starlette.testclient import TestClient
+
+from app.main import app
+
+
+def test_websocket_auto_push_on_connect() -> None:
+    """WebSocket should auto-push state and history on connect."""
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as ws:
+        # state is pushed automatically on connect
+        data = ws.receive_json()
+        assert data["type"] == "state"
+        assert "is_downloading" in data["data"]
+        assert "queue_size" in data["data"]
+        assert "connected_clients" in data["data"]
+
+        # history_complete follows immediately (empty DB)
+        data = ws.receive_json()
+        assert data["type"] == "history_complete"
+        assert data["data"]["total"] == 0
+
+
+def test_websocket_request_state() -> None:
+    """Client can still explicitly request state."""
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as ws:
+        # Consume auto-push messages
+        ws.receive_json()  # state
+        ws.receive_json()  # history_complete
+
+        # Explicitly request state
+        ws.send_json({"type": "request_state"})
+        data = ws.receive_json()
+        assert data["type"] == "state"
+
+
+def test_websocket_request_history() -> None:
+    """Client can still explicitly request history."""
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as ws:
+        # Consume auto-push messages
+        ws.receive_json()  # state
+        ws.receive_json()  # history_complete
+
+        # Explicitly request history
+        ws.send_json({"type": "request_history"})
+        data = ws.receive_json()
+        assert data["type"] == "history_complete"
+        assert data["data"]["total"] == 0
+
+
+def test_websocket_invalid_json() -> None:
+    """WebSocket should ignore invalid JSON without disconnecting."""
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as ws:
+        # Consume auto-push messages
+        ws.receive_json()  # state
+        ws.receive_json()  # history_complete
+
+        ws.send_text("not json")
+        # Should still respond to valid messages after invalid one
+        ws.send_json({"type": "request_state"})
+        data = ws.receive_json()
+        assert data["type"] == "state"


### PR DESCRIPTION
## Summary
Real-time WebSocket communication for download progress and state management.

## New Files
- app/ws/manager.py — ConnectionManager (client tracking + broadcast)
- app/ws/handler.py — WebSocket endpoint (/ws)
- tests/test_websocket.py — WebSocket connection and auto-push tests

## Modified Files
- app/services/download_manager.py — broadcast callback injection pattern
- app/main.py — WebSocket router + broadcast callback wiring in lifespan

## Key Design Decisions
- Auto-push on connect: state + history sent immediately (v1 behavior)
- request_state / request_history also supported for manual refresh
- JSON protocol (not v1 text format)
- No WebSocket auth (NAS local network, same as v1)
- Callback injection to avoid circular imports (download_manager ↔ ws_manager)
- Dead client auto-cleanup on broadcast failure

## Verification
- [x] /ws WebSocket endpoint functional
- [x] Auto-push state + history on connect
- [x] request_state / request_history manual refresh
- [x] Broadcast callback wired in lifespan
- [x] No circular imports
- [x] pytest passed
- [x] ruff check passed

## What's Next
- Wave 3a: Error handling (#49, #47)
- Wave 3b: File serving + history API enhancements
- Wave 3c: Docker optimization