### PR TITLE
Remember the last successful dashboard profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here.
 
 - Added a lightweight Library Overview to the existing history drawer with stored-file totals, 7-day and 14-day activity, media-type distribution, and recorded failure summaries computed from the current history response.
 - Added an accessible statistics drawer for compact and mobile layouts, with direct links from type and failure aggregates into existing history filters.
+- Remember the last successfully queued dashboard profile on each device while keeping submission explicit and falling back to Best for new or invalid local preferences.
 
 ### Security
 

--- a/static/logical_js/download-profile.js
+++ b/static/logical_js/download-profile.js
@@ -1,0 +1,106 @@
+(function(root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = api;
+    }
+    if (root) {
+        root.YDLNAS_DOWNLOAD_PROFILE = api;
+    }
+})(typeof window !== 'undefined' ? window : globalThis, function() {
+    const storageKey = 'ydlnasDownloadProfile:v1';
+    const videoProfiles = new Set([
+        'best', '2160p', '1440p', '1080p', '720p', '480p', '360p', '240p', '144p'
+    ]);
+    const audioProfiles = new Set(['audio', 'audio-m4a', 'audio-mp3']);
+    const subtitleProfiles = new Set(['srt', 'vtt']);
+    const subtitleLanguagePattern = /^[A-Za-z0-9_-]+(?:-[A-Za-z0-9_-]+)*$/;
+
+    function normalize(profile) {
+        if (!profile || typeof profile !== 'object') {
+            return null;
+        }
+
+        const resolution = String(profile.resolution || '').trim();
+        const mode = String(profile.mode || '').trim();
+        const subtitleLanguage = String(profile.subtitleLanguage || '').trim();
+        let expectedMode = '';
+
+        if (videoProfiles.has(resolution)) {
+            expectedMode = 'video';
+        } else if (audioProfiles.has(resolution)) {
+            expectedMode = 'audio';
+        } else if (subtitleProfiles.has(resolution)) {
+            expectedMode = 'subtitle';
+        } else {
+            return null;
+        }
+
+        if (mode !== expectedMode) {
+            return null;
+        }
+        if (expectedMode === 'subtitle' && subtitleLanguage && !subtitleLanguagePattern.test(subtitleLanguage)) {
+            return null;
+        }
+
+        return {
+            version: 1,
+            mode: expectedMode,
+            resolution: resolution,
+            subtitleLanguage: expectedMode === 'subtitle' ? subtitleLanguage : ''
+        };
+    }
+
+    function fromSubmission(resolutionValue) {
+        const value = String(resolutionValue || '').trim();
+        const separator = value.indexOf('|');
+        const resolution = separator >= 0 ? value.substring(0, separator) : value;
+        const subtitleLanguage = separator >= 0 ? value.substring(separator + 1) : '';
+        let mode = 'video';
+        if (audioProfiles.has(resolution)) {
+            mode = 'audio';
+        } else if (subtitleProfiles.has(resolution)) {
+            mode = 'subtitle';
+        }
+        return normalize({ mode: mode, resolution: resolution, subtitleLanguage: subtitleLanguage });
+    }
+
+    function load(storage) {
+        if (!storage || typeof storage.getItem !== 'function') {
+            return null;
+        }
+        try {
+            const value = storage.getItem(storageKey);
+            if (!value) {
+                return null;
+            }
+            const profile = normalize(JSON.parse(value));
+            if (!profile && typeof storage.removeItem === 'function') {
+                storage.removeItem(storageKey);
+            }
+            return profile;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function save(storage, resolutionValue) {
+        const profile = fromSubmission(resolutionValue);
+        if (!profile || !storage || typeof storage.setItem !== 'function') {
+            return null;
+        }
+        try {
+            storage.setItem(storageKey, JSON.stringify(profile));
+            return profile;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    return {
+        storageKey: storageKey,
+        fromSubmission: fromSubmission,
+        load: load,
+        normalize: normalize,
+        save: save
+    };
+});

--- a/static/logical_js/logic.js
+++ b/static/logical_js/logic.js
@@ -2471,6 +2471,49 @@ $(function () {
         });
     }
 
+    function downloadProfileStorage() {
+        try {
+            return window.localStorage;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function restoreDownloadProfile() {
+        const helper = window.YDLNAS_DOWNLOAD_PROFILE;
+        if (!helper || typeof helper.load !== 'function') {
+            return;
+        }
+        const profile = helper.load(downloadProfileStorage());
+        if (!profile) {
+            return;
+        }
+
+        const resolutionOption = $('#selResolution option').filter(function() {
+            return this.value === profile.resolution;
+        });
+        if (!resolutionOption.length) {
+            return;
+        }
+
+        $('#selResolution').val(profile.resolution).trigger('change');
+        if (profile.mode === 'subtitle' && profile.subtitleLanguage) {
+            const languageOption = $('#selSubtitleLanguage option').filter(function() {
+                return this.value === profile.subtitleLanguage;
+            });
+            if (languageOption.length) {
+                $('#selSubtitleLanguage').val(profile.subtitleLanguage);
+            }
+        }
+    }
+
+    function saveDownloadProfile(resolution) {
+        const helper = window.YDLNAS_DOWNLOAD_PROFILE;
+        if (helper && typeof helper.save === 'function') {
+            helper.save(downloadProfileStorage(), resolution);
+        }
+    }
+
     function syncModeFromResolution() {
         const selectedValue = $('#selResolution').val();
         let mode = 'video';
@@ -2550,6 +2593,9 @@ $(function () {
                     fetchStatus();
                     addMessage(translate('message.already_queued', { title: label }), 'warning');
                     return;
+                }
+                if (response.queued === true) {
+                    saveDownloadProfile(data.resolution);
                 }
                 $('#progress-container').show();
                 updateProgress(0);
@@ -2823,6 +2869,7 @@ $(function () {
     });
 
     applyHistoryPrefsToControls();
+    restoreDownloadProfile();
     syncModeFromResolution();
     updatePlaylistGuard();
     loadPreferences();

--- a/static/template/index.tpl
+++ b/static/template/index.tpl
@@ -497,6 +497,7 @@
     window.YDLNAS_I18N = {{!translations_json}};
     window.YDLNAS_SHARED_URL = {{!shared_url_json}};
 </script>
+<script src="youtube-dl/static/logical_js/download-profile.js?v={{app_version}}"></script>
 <script src="youtube-dl/static/logical_js/history-insights.js?v={{app_version}}"></script>
 <script src="youtube-dl/static/logical_js/logic.js?v={{app_version}}"></script>
 <script>

--- a/tests/test_download_profile.py
+++ b/tests/test_download_profile.py
@@ -1,0 +1,100 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE_MODULE = ROOT / "static" / "logical_js" / "download-profile.js"
+NODE = shutil.which("node")
+
+
+def run_profile_script(body):
+    if not NODE:
+        pytest.skip("Node.js is unavailable")
+    script = f"""
+const profile = require(process.argv[1]);
+{body}
+"""
+    completed = subprocess.run(
+        [NODE, "-e", script, str(PROFILE_MODULE)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_download_profile_saves_and_restores_supported_modes():
+    result = run_profile_script("""
+const values = new Map();
+const storage = {
+  getItem: (key) => values.has(key) ? values.get(key) : null,
+  setItem: (key, value) => values.set(key, value),
+  removeItem: (key) => values.delete(key)
+};
+const audio = profile.save(storage, 'audio-m4a');
+const restoredAudio = profile.load(storage);
+const subtitle = profile.save(storage, 'vtt|ko');
+const restoredSubtitle = profile.load(storage);
+process.stdout.write(JSON.stringify({audio, restoredAudio, subtitle, restoredSubtitle}));
+""")
+
+    assert result["audio"] == {
+        "version": 1,
+        "mode": "audio",
+        "resolution": "audio-m4a",
+        "subtitleLanguage": "",
+    }
+    assert result["restoredAudio"] == result["audio"]
+    assert result["subtitle"] == {
+        "version": 1,
+        "mode": "subtitle",
+        "resolution": "vtt",
+        "subtitleLanguage": "ko",
+    }
+    assert result["restoredSubtitle"] == result["subtitle"]
+
+
+def test_download_profile_rejects_stale_or_corrupt_preferences():
+    result = run_profile_script("""
+let removed = 0;
+const invalidStorage = {
+  getItem: () => JSON.stringify({version: 1, mode: 'video', resolution: 'raw-format'}),
+  removeItem: () => { removed += 1; }
+};
+const corruptStorage = {getItem: () => '{broken'};
+const blockedStorage = {
+  getItem: () => { throw new Error('blocked'); },
+  setItem: () => { throw new Error('blocked'); }
+};
+process.stdout.write(JSON.stringify({
+  invalid: profile.load(invalidStorage),
+  corrupt: profile.load(corruptStorage),
+  blockedLoad: profile.load(blockedStorage),
+  blockedSave: profile.save(blockedStorage, 'best'),
+  removed
+}));
+""")
+
+    assert result == {
+        "invalid": None,
+        "corrupt": None,
+        "blockedLoad": None,
+        "blockedSave": None,
+        "removed": 1,
+    }
+
+
+def test_download_profile_frontend_contract_saves_only_after_queue_success():
+    template = (ROOT / "static" / "template" / "index.tpl").read_text(encoding="utf-8")
+    logic = (ROOT / "static" / "logical_js" / "logic.js").read_text(encoding="utf-8")
+
+    assert template.index("download-profile.js") < template.index("logic.js")
+    success_block = logic[logic.index('success: function(response, status)'):logic.index('error: function(jqXHR, textStatus')]
+    assert success_block.index("if (response.duplicate)") < success_block.index("if (response.queued === true)")
+    assert "saveDownloadProfile(data.resolution)" in success_block
+    assert logic.rindex("restoreDownloadProfile();") < logic.rindex("syncModeFromResolution();")
+    assert "YDLNAS_SHARED_URL" in logic


### PR DESCRIPTION
## Summary
- persist the last profile only after a dashboard request is actually queued
- restore video, audio, or subtitle format on the same device without auto-submitting a URL
- keep Best for new devices and discard corrupt, stale, or unsupported local values
- leave duplicate, failed, retry, and mobile-share-default behavior unchanged

## Verification
- `./.venv/bin/python -m pytest -q` (97 passed)
- `node --check static/logical_js/download-profile.js`
- `node --check static/logical_js/logic.js`
- browser QA: Best on a fresh local app, successful M4A queue, reload restores Audio/M4A, URL remains empty, no repeated submission, no console errors

## Release
This PR intentionally performs CI image checks only. Docker publishing remains deferred to the consolidated weekend release.
