### PR TITLE
Support Docker secret files for credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 MY_ID=nas-user
+MY_ID_FILE=
 MY_PW=change-this-password
+MY_PW_FILE=
 TZ=Asia/Seoul
 WEB_PORT=8080
 DOWNLOAD_DIR=./downloads
@@ -18,5 +20,6 @@ YDLNAS_STORAGE_CRITICAL_GB=2
 
 # Optional integrations
 YDLNAS_API_TOKEN=
+YDLNAS_API_TOKEN_FILE=
 COOKIE_SECURE=false
 PROXY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here.
 - Added an accessible statistics drawer for compact and mobile layouts, with direct links from type and failure aggregates into existing history filters.
 - Remember the last successfully queued dashboard profile on each device while keeping submission explicit and falling back to Best for new or invalid local preferences.
 - Added an explicit Compatible MP4 profile that requires H.264 video and AAC audio without changing the existing Best and resolution profiles.
+- Added optional Docker secret-file inputs for the login ID, password, and API token while preserving direct environment variables as the default and precedence winner.
 
 ### Security
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -68,6 +68,7 @@ The second volume is strongly recommended. It preserves the restart-safe queue, 
 | --- | --- | --- | --- |
 | `MY_ID` | Yes | - | Dashboard and REST login ID |
 | `MY_PW` | Yes | - | Dashboard and REST password |
+| `MY_ID_FILE` / `MY_PW_FILE` | No | Empty | Advanced mounted-secret alternatives; direct variables take precedence |
 | `TZ` | No | System default | Container time zone, such as `Asia/Seoul` |
 | `APP_PORT` | No | `8080` | App port when using host networking |
 | `PUID` / `PGID` | No | `0` | Owner for new download and state files |
@@ -81,6 +82,7 @@ The second volume is strongly recommended. It preserves the restart-safe queue, 
 | `NLPTUTTI_AUTO_UPDATE` | No | `true` | Install or upgrade `nlptutti` at new-container startup for Subtitle QA |
 | `NLPTUTTI_UPDATE_TIMEOUT` | No | `180` | Runtime package-update timeout in seconds |
 | `YDLNAS_API_TOKEN` | No | Empty | Optional Bearer token; ID/password remains supported |
+| `YDLNAS_API_TOKEN_FILE` | No | Empty | Advanced mounted-secret alternative; the direct token takes precedence |
 | `COOKIE_SECURE` | No | `false` | Set `true` behind an HTTPS-only reverse proxy |
 
 See the [complete Docker options](https://github.com/hyeonsangjeon/youtube-dl-nas#docker-options) for updater controls and deployment examples.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ docker run -d \
 | `-p host:guest` | Port forwarding. The app defaults to `8080`. |
 | `-e MY_ID` | Required login ID. Avoid values starting with `!`, `$`, or `&`. |
 | `-e MY_PW` | Required login password. Avoid values starting with `!`, `$`, or `&`. |
+| `-e MY_ID_FILE` | Advanced alternative: read the login ID from one mounted secret file. `MY_ID` wins when both are set. |
+| `-e MY_PW_FILE` | Advanced alternative: read the login password from one mounted secret file. `MY_PW` wins when both are set. |
 | `-e TZ` | Optional container time zone, for example `Asia/Seoul`. |
 | `-e APP_PORT` | Optional app port. Defaults to `8080`. |
 | `-e PROXY` | Optional proxy value passed to `yt-dlp`. Defaults to empty. |
@@ -187,7 +189,35 @@ docker run -d \
 | `-e YDLNAS_STORAGE_WARNING_GB` | Free-space warning threshold in GiB. Defaults to `10`; set `0` to disable. |
 | `-e YDLNAS_STORAGE_CRITICAL_GB` | Free-space threshold that pauses new queue additions. Defaults to `2`; set `0` to disable. |
 | `-e YDLNAS_API_TOKEN` | Optional Bearer token for integrations. Normal ID/password API authentication remains available. |
+| `-e YDLNAS_API_TOKEN_FILE` | Advanced alternative: read the optional Bearer token from one mounted secret file. The direct variable wins when both are set. |
 | `-e COOKIE_SECURE` | Set to `true` when the dashboard is served exclusively over HTTPS. |
+
+### Docker Compose Secrets
+
+Environment variables remain the simplest choice for Synology and other NAS interfaces. Advanced Compose deployments can mount one secret per file and point the matching `_FILE` variable at `/run/secrets/...`:
+
+```yaml
+services:
+  youtube-dl-nas:
+    environment:
+      MY_ID_FILE: /run/secrets/ydlnas_id
+      MY_PW_FILE: /run/secrets/ydlnas_password
+      YDLNAS_API_TOKEN_FILE: /run/secrets/ydlnas_api_token
+    secrets:
+      - ydlnas_id
+      - ydlnas_password
+      - ydlnas_api_token
+
+secrets:
+  ydlnas_id:
+    file: ./secrets/id.txt
+  ydlnas_password:
+    file: ./secrets/password.txt
+  ydlnas_api_token:
+    file: ./secrets/api-token.txt
+```
+
+Leave the corresponding direct variable empty when using its file form. A non-empty direct variable always takes precedence. Startup stops with a concise error when a requested file is missing, unreadable, not a regular file, or empty; secret values are never printed.
 
 ## Mobile Sharing
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,8 +6,10 @@ services:
     ports:
       - "${WEB_PORT:-8080}:8080"
     environment:
-      MY_ID: "${MY_ID:?Set MY_ID in .env}"
-      MY_PW: "${MY_PW:?Set MY_PW in .env}"
+      MY_ID: "${MY_ID:-}"
+      MY_ID_FILE: "${MY_ID_FILE:-}"
+      MY_PW: "${MY_PW:-}"
+      MY_PW_FILE: "${MY_PW_FILE:-}"
       TZ: "${TZ:-UTC}"
       DOWNLOAD_DIR: "/downfolder"
       STATE_DIR: "/usr/src/app/metadata"
@@ -24,6 +26,7 @@ services:
       YDLNAS_STORAGE_WARNING_GB: "${YDLNAS_STORAGE_WARNING_GB:-10}"
       YDLNAS_STORAGE_CRITICAL_GB: "${YDLNAS_STORAGE_CRITICAL_GB:-2}"
       YDLNAS_API_TOKEN: "${YDLNAS_API_TOKEN:-}"
+      YDLNAS_API_TOKEN_FILE: "${YDLNAS_API_TOKEN_FILE:-}"
       COOKIE_SECURE: "${COOKIE_SECURE:-false}"
       PROXY: "${PROXY:-}"
     volumes:

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -38,6 +38,12 @@ docker compose ps
 Open `http://<nas-address>:<WEB_PORT>` and sign in with the configured ID and
 password. Use HTTPS before exposing the dashboard outside a trusted network.
 
+For Compose secrets, mount one file per value and set `MY_ID_FILE`,
+`MY_PW_FILE`, or `YDLNAS_API_TOKEN_FILE` to its container path. Direct
+environment variables remain the default and take precedence when both forms
+are configured. A requested secret file must be a readable, non-empty regular
+file; startup errors identify only the variable and never print its contents.
+
 ## Upgrade
 
 Back up or snapshot `DOWNLOAD_DIR` and `CONFIG_DIR` before changing an image or

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -u
 
-APP_DIR=/usr/src/app
+APP_DIR=${APP_DIR:-/usr/src/app}
 STATE_DIR=${STATE_DIR:-$APP_DIR/metadata}
 DOWNLOAD_DIR=${DOWNLOAD_DIR:-/downfolder}
 PUID=${PUID:-0}
@@ -11,6 +11,37 @@ YTDLP_AUTO_UPDATE=${YTDLP_AUTO_UPDATE:-true}
 NLPTUTTI_AUTO_UPDATE=${NLPTUTTI_AUTO_UPDATE:-true}
 SCHEDULER_PID=""
 SERVER_PID=""
+
+resolve_secret_file() {
+  local value_name=$1
+  local file_name="${value_name}_FILE"
+  local value=${!value_name-}
+  local file_path=${!file_name-}
+
+  # Preserve the existing environment-variable behavior when both forms exist.
+  if [ -n "$value" ] || [ -z "$file_path" ]; then
+    return
+  fi
+  if [ ! -f "$file_path" ] || [ ! -r "$file_path" ]; then
+    echo "$file_name points to a missing or unreadable regular file" >&2
+    exit 1
+  fi
+
+  if ! value=$(cat -- "$file_path"); then
+    echo "$file_name could not be read" >&2
+    exit 1
+  fi
+  if [ -z "$value" ]; then
+    echo "$file_name points to an empty file" >&2
+    exit 1
+  fi
+  printf -v "$value_name" '%s' "$value"
+  export "$value_name"
+}
+
+resolve_secret_file MY_ID
+resolve_secret_file MY_PW
+resolve_secret_file YDLNAS_API_TOKEN
 
 case "$PUID" in
   *[!0-9]*|'')

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,150 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTRYPOINT = ROOT / "run.sh"
+
+
+def make_fake_app(tmp_path, expected):
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    (app_dir / "Auth.json").write_text("{}", encoding="utf-8")
+    checks = "\n".join(
+        f"assert os.environ.get({name!r}) == {value!r}" for name, value in expected.items()
+    )
+    (app_dir / "youtube-dl-server.py").write_text(
+        "import os\n" + checks + "\n",
+        encoding="utf-8",
+    )
+    return app_dir
+
+
+def entrypoint_env(tmp_path, app_dir):
+    env = os.environ.copy()
+    env.update({
+        "APP_DIR": str(app_dir),
+        "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+        "STATE_DIR": str(tmp_path / "state"),
+        "YTDLP_AUTO_UPDATE": "false",
+        "NLPTUTTI_AUTO_UPDATE": "false",
+        "PATH": str(Path(sys.executable).parent) + os.pathsep + env.get("PATH", ""),
+    })
+    for name in (
+        "MY_ID", "MY_ID_FILE", "MY_PW", "MY_PW_FILE",
+        "YDLNAS_API_TOKEN", "YDLNAS_API_TOKEN_FILE",
+    ):
+        env.pop(name, None)
+    return env
+
+
+def test_entrypoint_reads_credentials_and_token_from_secret_files(tmp_path):
+    secrets = {
+        "MY_ID": "file-user",
+        "MY_PW": "file-password",
+        "YDLNAS_API_TOKEN": "file-token",
+    }
+    app_dir = make_fake_app(tmp_path, secrets)
+    env = entrypoint_env(tmp_path, app_dir)
+    for name, value in secrets.items():
+        path = tmp_path / name.lower()
+        path.write_text(value + "\n", encoding="utf-8")
+        env[f"{name}_FILE"] = str(path)
+
+    completed = subprocess.run(
+        ["bash", str(ENTRYPOINT)],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert all(value not in completed.stdout + completed.stderr for value in secrets.values())
+
+
+def test_direct_environment_values_take_precedence_over_secret_files(tmp_path):
+    expected = {
+        "MY_ID": "direct-user",
+        "MY_PW": "direct-password",
+        "YDLNAS_API_TOKEN": "direct-token",
+    }
+    app_dir = make_fake_app(tmp_path, expected)
+    env = entrypoint_env(tmp_path, app_dir)
+    env.update(expected)
+    for name in expected:
+        env[f"{name}_FILE"] = str(tmp_path / "does-not-need-to-exist")
+
+    completed = subprocess.run(
+        ["bash", str(ENTRYPOINT)],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_entrypoint_rejects_missing_and_empty_secret_files_without_leaking_values(tmp_path):
+    app_dir = make_fake_app(tmp_path, {})
+    base_env = entrypoint_env(tmp_path, app_dir)
+
+    missing_env = dict(base_env, MY_PW_FILE=str(tmp_path / "missing-secret"))
+    missing = subprocess.run(
+        ["bash", str(ENTRYPOINT)],
+        cwd=ROOT,
+        env=missing_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert missing.returncode != 0
+    assert "MY_PW_FILE points to a missing or unreadable regular file" in missing.stderr
+
+    empty_path = tmp_path / "empty-secret"
+    empty_path.write_text("", encoding="utf-8")
+    empty_env = dict(base_env, YDLNAS_API_TOKEN_FILE=str(empty_path))
+    empty = subprocess.run(
+        ["bash", str(ENTRYPOINT)],
+        cwd=ROOT,
+        env=empty_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert empty.returncode != 0
+    assert "YDLNAS_API_TOKEN_FILE points to an empty file" in empty.stderr
+
+
+def test_entrypoint_rejects_an_unreadable_secret_file(tmp_path):
+    if os.geteuid() == 0:
+        pytest.skip("root can read files regardless of owner permission bits")
+
+    app_dir = make_fake_app(tmp_path, {})
+    secret_path = tmp_path / "unreadable-secret"
+    secret_path.write_text("must-not-appear", encoding="utf-8")
+    secret_path.chmod(0)
+    env = entrypoint_env(tmp_path, app_dir)
+    env["MY_PW_FILE"] = str(secret_path)
+    try:
+        completed = subprocess.run(
+            ["bash", str(ENTRYPOINT)],
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        secret_path.chmod(0o600)
+
+    assert completed.returncode != 0
+    assert "MY_PW_FILE points to a missing or unreadable regular file" in completed.stderr
+    assert "must-not-appear" not in completed.stdout + completed.stderr


### PR DESCRIPTION
## Summary
- support `MY_ID_FILE`, `MY_PW_FILE`, and `YDLNAS_API_TOKEN_FILE` in the container entrypoint
- preserve direct environment variables as the simple default and precedence winner
- document an optional Docker Compose secrets setup and fail safely on invalid secret files

## Verification
- `.venv/bin/pytest -q` (107 passed)
- `bash -n run.sh`
- `docker compose --env-file .env.example config --quiet`
- focused tests cover file loading, environment precedence, missing/empty/unreadable files, and output redaction